### PR TITLE
Update marc-mabe/php-enum constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=7.0",
-    "marc-mabe/php-enum" : "2.2.*"
+    "marc-mabe/php-enum" : ">=2.2,<5"
   },
   "require-dev": {
     "theseer/phpdox": "0.8.*"


### PR DESCRIPTION
This still works fine with the latest version of Enum and this change allows users of your libraries to upgrade their dependencies.

Thanks