### PR TITLE
Add license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "ltd-beget/ascii-table",
   "type": "library",
   "description": "Php library with ascii table enum.",
+  "license": "MIT",
   "keywords": [
     "ascii"
   ],


### PR DESCRIPTION
Right now `composer license` shows this project as unlicensed.